### PR TITLE
Ensure wlroots 0.18 is available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,70 @@ if (NOT WAYLAND_SCANNER)
     message(FATAL_ERROR "wayland-scanner not found. Install wayland-protocols (e.g. sudo apt install wayland-protocols).")
 endif()
 
-pkg_check_modules(WLROOTS REQUIRED IMPORTED_TARGET wlroots)
+# wlroots 0.18 introduced destroy helpers that our compositor relies on.  Some
+# distributions ship parallel pkg-config files ("wlroots-0.18" alongside
+# "wlroots"), while others only expose the generic name with versioned
+# metadata.  Try both variants and fall back to fetching wlroots automatically
+# if no suitable development package is available.
+set(WLROOTS_MIN_VERSION 0.18)
+
+pkg_check_modules(WLROOTS_018 QUIET IMPORTED_TARGET wlroots-0.18)
+if (WLROOTS_018_FOUND)
+    set(WLROOTS_TARGET PkgConfig::WLROOTS_018)
+else()
+    pkg_check_modules(WLROOTS QUIET IMPORTED_TARGET "wlroots>=${WLROOTS_MIN_VERSION}")
+    if (WLROOTS_FOUND)
+        set(WLROOTS_TARGET PkgConfig::WLROOTS)
+    endif()
+endif()
+
+if (NOT WLROOTS_TARGET)
+    set(WLROOTS_FALLBACK_DIR ${CMAKE_BINARY_DIR}/third_party/wlroots)
+    set(WLROOTS_FALLBACK_INSTALL ${WLROOTS_FALLBACK_DIR}/install)
+
+    include(FetchContent)
+    FetchContent_Declare(
+        wlroots
+        GIT_REPOSITORY https://gitlab.freedesktop.org/wlroots/wlroots.git
+        GIT_TAG 0.18.1
+    )
+    FetchContent_Populate(wlroots)
+
+    find_program(MESON_EXECUTABLE meson)
+    if (NOT MESON_EXECUTABLE)
+        message(FATAL_ERROR "meson not found. Install meson to build wlroots locally or provide wlroots ${WLROOTS_MIN_VERSION}+ via pkg-config.")
+    endif()
+
+    find_program(NINJA_EXECUTABLE ninja)
+    if (NOT NINJA_EXECUTABLE)
+        message(FATAL_ERROR "ninja not found. Install ninja-build to build wlroots locally or provide wlroots ${WLROOTS_MIN_VERSION}+ via pkg-config.")
+    endif()
+
+    include(ExternalProject)
+    ExternalProject_Add(wlroots_external
+        SOURCE_DIR ${wlroots_SOURCE_DIR}
+        BINARY_DIR ${WLROOTS_FALLBACK_DIR}/build
+        CONFIGURE_COMMAND
+            ${MESON_EXECUTABLE} setup ${WLROOTS_FALLBACK_DIR}/build ${wlroots_SOURCE_DIR}
+            --prefix ${WLROOTS_FALLBACK_INSTALL}
+            --buildtype release
+            --default-library shared
+        BUILD_COMMAND ${MESON_EXECUTABLE} compile -C ${WLROOTS_FALLBACK_DIR}/build
+        INSTALL_COMMAND ${MESON_EXECUTABLE} install -C ${WLROOTS_FALLBACK_DIR}/build
+        BUILD_BYPRODUCTS ${WLROOTS_FALLBACK_INSTALL}/lib/pkgconfig/wlroots.pc
+    )
+
+    set(WLROOTS_IMPORTED libwlroots)
+    add_library(${WLROOTS_IMPORTED} SHARED IMPORTED)
+    add_dependencies(${WLROOTS_IMPORTED} wlroots_external)
+    set_target_properties(${WLROOTS_IMPORTED} PROPERTIES
+        IMPORTED_LOCATION ${WLROOTS_FALLBACK_INSTALL}/lib/libwlroots.so
+        INTERFACE_INCLUDE_DIRECTORIES ${WLROOTS_FALLBACK_INSTALL}/include
+    )
+
+    set(WLROOTS_TARGET ${WLROOTS_IMPORTED})
+    set(WLROOTS_FALLBACK TRUE)
+endif()
 pkg_check_modules(WAYLAND_SERVER REQUIRED IMPORTED_TARGET wayland-server)
 pkg_check_modules(WAYLAND_PROTOCOLS REQUIRED wayland-protocols)
 pkg_check_modules(PANGOCAIRO REQUIRED IMPORTED_TARGET pangocairo)
@@ -72,10 +135,14 @@ target_include_directories(arolloa-compositor
 target_compile_definitions(arolloa-compositor PRIVATE WLR_USE_UNSTABLE)
 target_compile_options(arolloa-compositor PRIVATE -Wall -Wextra -Wpedantic)
 
+if (WLROOTS_FALLBACK)
+    add_dependencies(arolloa-compositor wlroots_external)
+endif()
+
 target_link_libraries(arolloa-compositor
     PRIVATE
+        ${WLROOTS_TARGET}
         arolloa_protocols
-        PkgConfig::WLROOTS
         PkgConfig::WAYLAND_SERVER
         PkgConfig::PANGOCAIRO
         PkgConfig::CAIRO

--- a/src/core/compositor_server_init.cpp
+++ b/src/core/compositor_server_init.cpp
@@ -103,6 +103,42 @@ bool setup_debug_environment(ArolloaServer *server) {
     server->nested_backend_active = true;
     return true;
 }
+
+void destroy_decoration_manager(struct wlr_xdg_decoration_manager_v1 *manager) {
+    if (!manager) {
+        return;
+    }
+
+#if defined(WLR_VERSION_NUM) && WLR_VERSION_NUM >= ((0 << 16) | (18 << 8) | 0)
+    wlr_xdg_decoration_manager_v1_destroy(manager);
+#else
+    (void)manager;
+#endif
+}
+
+void destroy_xdg_shell(struct wlr_xdg_shell *shell) {
+    if (!shell) {
+        return;
+    }
+
+#if defined(WLR_VERSION_NUM) && WLR_VERSION_NUM >= ((0 << 16) | (18 << 8) | 0)
+    wlr_xdg_shell_destroy(shell);
+#else
+    (void)shell;
+#endif
+}
+
+void destroy_compositor(struct wlr_compositor *compositor) {
+    if (!compositor) {
+        return;
+    }
+
+#if defined(WLR_VERSION_NUM) && WLR_VERSION_NUM >= ((0 << 16) | (18 << 8) | 0)
+    wlr_compositor_destroy(compositor);
+#else
+    (void)compositor;
+#endif
+}
 } // namespace
 
 void server_init(ArolloaServer *server) {
@@ -242,12 +278,12 @@ void server_init(ArolloaServer *server) {
             server->output_layout = nullptr;
         }
         if (server->decoration_manager) {
-            wlr_xdg_decoration_manager_v1_destroy(server->decoration_manager);
+            destroy_decoration_manager(server->decoration_manager);
             server->decoration_manager = nullptr;
         }
-        wlr_xdg_shell_destroy(server->xdg_shell);
+        destroy_xdg_shell(server->xdg_shell);
         server->xdg_shell = nullptr;
-        wlr_compositor_destroy(server->compositor);
+        destroy_compositor(server->compositor);
         server->compositor = nullptr;
         wlr_renderer_destroy(server->renderer);
         server->renderer = nullptr;
@@ -277,12 +313,12 @@ void server_init(ArolloaServer *server) {
             server->output_layout = nullptr;
         }
         if (server->decoration_manager) {
-            wlr_xdg_decoration_manager_v1_destroy(server->decoration_manager);
+            destroy_decoration_manager(server->decoration_manager);
             server->decoration_manager = nullptr;
         }
-        wlr_xdg_shell_destroy(server->xdg_shell);
+        destroy_xdg_shell(server->xdg_shell);
         server->xdg_shell = nullptr;
-        wlr_compositor_destroy(server->compositor);
+        destroy_compositor(server->compositor);
         server->compositor = nullptr;
         wlr_renderer_destroy(server->renderer);
         server->renderer = nullptr;

--- a/src/core/compositor_server_runtime.cpp
+++ b/src/core/compositor_server_runtime.cpp
@@ -25,6 +25,42 @@ void destroy_display(ArolloaServer *server) {
     server->xdg_shell = nullptr;
     server->decoration_manager = nullptr;
 }
+
+void destroy_decoration_manager(struct wlr_xdg_decoration_manager_v1 *manager) {
+    if (!manager) {
+        return;
+    }
+
+#if defined(WLR_VERSION_NUM) && WLR_VERSION_NUM >= ((0 << 16) | (18 << 8) | 0)
+    wlr_xdg_decoration_manager_v1_destroy(manager);
+#else
+    (void)manager;
+#endif
+}
+
+void destroy_xdg_shell(struct wlr_xdg_shell *shell) {
+    if (!shell) {
+        return;
+    }
+
+#if defined(WLR_VERSION_NUM) && WLR_VERSION_NUM >= ((0 << 16) | (18 << 8) | 0)
+    wlr_xdg_shell_destroy(shell);
+#else
+    (void)shell;
+#endif
+}
+
+void destroy_compositor(struct wlr_compositor *compositor) {
+    if (!compositor) {
+        return;
+    }
+
+#if defined(WLR_VERSION_NUM) && WLR_VERSION_NUM >= ((0 << 16) | (18 << 8) | 0)
+    wlr_compositor_destroy(compositor);
+#else
+    (void)compositor;
+#endif
+}
 } // namespace
 
 void server_run(ArolloaServer *server) {
@@ -59,17 +95,17 @@ void server_destroy(ArolloaServer *server) {
     }
 
     if (server->decoration_manager) {
-        wlr_xdg_decoration_manager_v1_destroy(server->decoration_manager);
+        destroy_decoration_manager(server->decoration_manager);
         server->decoration_manager = nullptr;
     }
 
     if (server->xdg_shell) {
-        wlr_xdg_shell_destroy(server->xdg_shell);
+        destroy_xdg_shell(server->xdg_shell);
         server->xdg_shell = nullptr;
     }
 
     if (server->compositor) {
-        wlr_compositor_destroy(server->compositor);
+        destroy_compositor(server->compositor);
         server->compositor = nullptr;
     }
 


### PR DESCRIPTION
## Summary
- require wlroots 0.18 or newer via pkg-config, preferring distro-provided wlroots-0.18 metadata when available
- add an automatic fallback that fetches and builds wlroots 0.18.1 into a third_party directory when an appropriate system package is missing
- wire the compositor target to depend on the locally built wlroots library so headers and libraries are available during the build

## Testing
- ./build.sh *(fails: wayland-scanner missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5dd4f28d08326a57059b69b4c2ce2