### PR TITLE
Fix wlroots 0.18 compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,9 @@ if (NOT WAYLAND_SCANNER)
     message(FATAL_ERROR "wayland-scanner not found. Install wayland-protocols (e.g. sudo apt install wayland-protocols).")
 endif()
 
-# wlroots 0.18 introduced destroy helpers that our compositor relies on.  Some
+# wlroots 0.18 tweaked a number of APIs (for example, the output layout factory
+# now requires a wl_display argument) and is the first version our compositor is
+# able to build against without additional compatibility shims.  Some
 # distributions ship parallel pkg-config files ("wlroots-0.18" alongside
 # "wlroots"), while others only expose the generic name with versioned
 # metadata.  Try both variants and fall back to fetching wlroots automatically

--- a/src/core/compositor_server_init.cpp
+++ b/src/core/compositor_server_init.cpp
@@ -54,6 +54,15 @@ struct wlr_xdg_shell *create_xdg_shell(struct wl_display *display) {
 #endif
 }
 
+struct wlr_output_layout *create_output_layout(struct wl_display *display) {
+#if defined(WLR_VERSION_NUM) && WLR_VERSION_NUM >= ((0 << 16) | (18 << 8) | 0)
+    return wlr_output_layout_create(display);
+#else
+    (void)display;
+    return wlr_output_layout_create();
+#endif
+}
+
 void destroy_display(ArolloaServer *server) {
     if (!server || !server->wl_display) {
         return;
@@ -109,7 +118,7 @@ void destroy_decoration_manager(struct wlr_xdg_decoration_manager_v1 *manager) {
         return;
     }
 
-#if defined(WLR_VERSION_NUM) && WLR_VERSION_NUM >= ((0 << 16) | (18 << 8) | 0)
+#if !defined(WLR_VERSION_NUM) || WLR_VERSION_NUM < ((0 << 16) | (18 << 8) | 0)
     wlr_xdg_decoration_manager_v1_destroy(manager);
 #else
     (void)manager;
@@ -121,7 +130,7 @@ void destroy_xdg_shell(struct wlr_xdg_shell *shell) {
         return;
     }
 
-#if defined(WLR_VERSION_NUM) && WLR_VERSION_NUM >= ((0 << 16) | (18 << 8) | 0)
+#if !defined(WLR_VERSION_NUM) || WLR_VERSION_NUM < ((0 << 16) | (18 << 8) | 0)
     wlr_xdg_shell_destroy(shell);
 #else
     (void)shell;
@@ -133,7 +142,7 @@ void destroy_compositor(struct wlr_compositor *compositor) {
         return;
     }
 
-#if defined(WLR_VERSION_NUM) && WLR_VERSION_NUM >= ((0 << 16) | (18 << 8) | 0)
+#if !defined(WLR_VERSION_NUM) || WLR_VERSION_NUM < ((0 << 16) | (18 << 8) | 0)
     wlr_compositor_destroy(compositor);
 #else
     (void)compositor;
@@ -257,7 +266,7 @@ void server_init(ArolloaServer *server) {
     }
 
     server->decoration_manager = wlr_xdg_decoration_manager_v1_create(server->wl_display);
-    server->output_layout = wlr_output_layout_create();
+    server->output_layout = create_output_layout(server->wl_display);
 
     wl_list_init(&server->outputs);
     wl_list_init(&server->views);

--- a/src/core/compositor_server_runtime.cpp
+++ b/src/core/compositor_server_runtime.cpp
@@ -31,7 +31,7 @@ void destroy_decoration_manager(struct wlr_xdg_decoration_manager_v1 *manager) {
         return;
     }
 
-#if defined(WLR_VERSION_NUM) && WLR_VERSION_NUM >= ((0 << 16) | (18 << 8) | 0)
+#if !defined(WLR_VERSION_NUM) || WLR_VERSION_NUM < ((0 << 16) | (18 << 8) | 0)
     wlr_xdg_decoration_manager_v1_destroy(manager);
 #else
     (void)manager;
@@ -43,7 +43,7 @@ void destroy_xdg_shell(struct wlr_xdg_shell *shell) {
         return;
     }
 
-#if defined(WLR_VERSION_NUM) && WLR_VERSION_NUM >= ((0 << 16) | (18 << 8) | 0)
+#if !defined(WLR_VERSION_NUM) || WLR_VERSION_NUM < ((0 << 16) | (18 << 8) | 0)
     wlr_xdg_shell_destroy(shell);
 #else
     (void)shell;
@@ -55,7 +55,7 @@ void destroy_compositor(struct wlr_compositor *compositor) {
         return;
     }
 
-#if defined(WLR_VERSION_NUM) && WLR_VERSION_NUM >= ((0 << 16) | (18 << 8) | 0)
+#if !defined(WLR_VERSION_NUM) || WLR_VERSION_NUM < ((0 << 16) | (18 << 8) | 0)
     wlr_compositor_destroy(compositor);
 #else
     (void)compositor;


### PR DESCRIPTION
## Summary
- add a compatibility helper for wlr_output_layout_create so wlroots 0.18 builds correctly
- guard wlroots destroy helpers so older releases provide cleanup and newer ones build without undefined symbols
- clarify the wlroots dependency comment in CMake

## Testing
- cmake -S . -B build *(fails: missing wayland-scanner in container image)*

------
https://chatgpt.com/codex/tasks/task_e_68d5eaa00b44832692ecaa88f83434dd