### PR TITLE
Add forest desktop experience with pointer support

### DIFF
--- a/src/core/compositor_input.cpp
+++ b/src/core/compositor_input.cpp
@@ -1,8 +1,181 @@
 #include "../../include/arolloa.h"
 
+#include <algorithm>
+#include <chrono>
 #include <cstdlib>
+#include <thread>
+
+#include <linux/input-event-codes.h>
 
 namespace {
+using namespace std::chrono_literals;
+
+uint8_t to_channel(float value) {
+    return static_cast<uint8_t>(std::clamp(value, 0.0f, 1.0f) * 255.0f + 0.5f);
+}
+
+void mark_last_interaction(ArolloaServer *server) {
+    if (!server) {
+        return;
+    }
+    server->ui_state.last_interaction = std::chrono::steady_clock::now();
+}
+
+void spawn_command_async(const std::string &command) {
+    if (command.empty()) {
+        return;
+    }
+
+    std::thread([command]() {
+        std::string wrapped = command;
+        if (!wrapped.empty() && wrapped.back() != '&') {
+            wrapped += " &";
+        }
+        std::system(wrapped.c_str());
+    }).detach();
+}
+
+std::vector<uint32_t> build_forest_cursor(uint32_t size) {
+    std::vector<uint32_t> pixels(size * size, 0x00000000);
+    const auto body_color = SwissDesign::Forest::MOSS_ACCENT;
+    const auto outline_color = SwissDesign::Forest::BARK;
+    const auto accent_color = SwissDesign::Forest::SUNLIGHT;
+
+    for (uint32_t y = 0; y < size; ++y) {
+        for (uint32_t x = 0; x < size; ++x) {
+            bool fill = false;
+            bool outline = false;
+            bool accent = false;
+
+            if (x <= y && y < size - 5 && x < size / 2) {
+                fill = true;
+                outline = (x == y) || (x == 0) || (y == 0);
+                accent = (x <= 2 && y % 3 == 0);
+            }
+
+            if (y >= size - 5 && x < size / 3) {
+                fill = true;
+                outline = outline || x == 0 || x == size / 3 - 1 || y == size - 1;
+                accent = accent || (y == size - 3 && x == 1);
+            }
+
+            if (!fill && !outline) {
+                continue;
+            }
+
+            SwissDesign::Color color = body_color;
+            if (outline) {
+                color = outline_color;
+            } else if (accent) {
+                color = accent_color;
+            }
+
+            const uint8_t r = to_channel(color.r);
+            const uint8_t g = to_channel(color.g);
+            const uint8_t b = to_channel(color.b);
+            const uint8_t a = to_channel(std::min(color.a, 1.0f));
+            pixels[y * size + x] = (static_cast<uint32_t>(a) << 24) |
+                                   (static_cast<uint32_t>(r) << 16) |
+                                   (static_cast<uint32_t>(g) << 8) |
+                                   static_cast<uint32_t>(b);
+        }
+    }
+
+    return pixels;
+}
+
+void remove_listener_safe(struct wl_listener *listener) {
+    if (!listener) {
+        return;
+    }
+    if (listener->link.prev || listener->link.next) {
+        wl_list_remove(&listener->link);
+        listener->link.prev = nullptr;
+        listener->link.next = nullptr;
+    }
+}
+
+bool pointer_in_panel(const ArolloaServer *server) {
+    return server && server->cursor_y <= static_cast<double>(SwissDesign::PANEL_HEIGHT);
+}
+
+bool handle_launcher_click(ArolloaServer *server, const wlr_pointer_button_event *event) {
+    if (!server->ui_state.launcher_visible || event->state != WLR_BUTTON_PRESSED) {
+        return false;
+    }
+
+    struct wlr_output *output = wlr_output_layout_output_at(server->output_layout, server->cursor_x, server->cursor_y);
+    if (!output) {
+        server->ui_state.launcher_visible = false;
+        mark_last_interaction(server);
+        return true;
+    }
+
+    int width = 0;
+    int height = 0;
+    wlr_output_effective_resolution(output, &width, &height);
+
+    const double launcher_width = FOREST_LAUNCHER_WIDTH;
+    const double launcher_height = std::min<double>(height * 0.6,
+        std::max<double>(SwissDesign::PANEL_HEIGHT * 4.0,
+            server->ui_state.launcher_entries.size() * FOREST_LAUNCHER_ENTRY_HEIGHT + 96.0));
+
+    const double start_x = (width - launcher_width) / 2.0;
+    const double start_y = (height - launcher_height) / 2.0;
+    const double local_x = server->cursor_x - start_x;
+    const double local_y = server->cursor_y - start_y;
+
+    if (local_x < 0.0 || local_y < 0.0 || local_x > launcher_width || local_y > launcher_height) {
+        server->ui_state.launcher_visible = false;
+        mark_last_interaction(server);
+        return true;
+    }
+
+    if (local_y < 72.0) {
+        return true;
+    }
+
+    const std::size_t index = static_cast<std::size_t>((local_y - 72.0) / FOREST_LAUNCHER_ENTRY_HEIGHT);
+    if (index < server->ui_state.launcher_entries.size()) {
+        server->ui_state.highlighted_index = index;
+        mark_last_interaction(server);
+        activate_launcher_selection(server);
+    }
+
+    return true;
+}
+
+bool handle_panel_click(ArolloaServer *server, const wlr_pointer_button_event *event) {
+    if (event->state != WLR_BUTTON_PRESSED || !pointer_in_panel(server)) {
+        return false;
+    }
+
+    mark_last_interaction(server);
+
+    if (event->button != BTN_LEFT) {
+        return true;
+    }
+
+    if (server->cursor_x < FOREST_PANEL_MENU_WIDTH) {
+        toggle_launcher(server);
+        return true;
+    }
+
+    double x = server->cursor_x - FOREST_PANEL_MENU_WIDTH;
+    const double icon_size = 28.0;
+    const double spacing = 12.0;
+
+    for (const auto &app : server->ui_state.panel_apps) {
+        if (x >= 0.0 && x <= icon_size + spacing) {
+            spawn_command_async(app.command);
+            return true;
+        }
+        x -= icon_size + spacing;
+    }
+
+    return true;
+}
+
 void keyboard_handle_modifiers(struct wl_listener *listener, void *data) {
     (void)data;
     ArolloaKeyboard *keyboard = wl_container_of(listener, keyboard, modifiers);
@@ -36,12 +209,224 @@ void keyboard_handle_key(struct wl_listener *listener, void *data) {
         }
     }
 
+    if (!handled && event->state == WL_KEYBOARD_KEY_STATE_PRESSED) {
+        for (int i = 0; i < nsyms; ++i) {
+            const xkb_keysym_t sym = syms[i];
+            if ((modifiers & WLR_MODIFIER_LOGO) && sym == XKB_KEY_space) {
+                toggle_launcher(server);
+                mark_last_interaction(server);
+                handled = true;
+                break;
+            }
+
+            if (server->ui_state.launcher_visible) {
+                if (sym == XKB_KEY_Escape) {
+                    server->ui_state.launcher_visible = false;
+                    mark_last_interaction(server);
+                    handled = true;
+                    break;
+                }
+                if (sym == XKB_KEY_Return || sym == XKB_KEY_KP_Enter) {
+                    handled = activate_launcher_selection(server);
+                    break;
+                }
+                if (sym == XKB_KEY_Up) {
+                    focus_launcher_offset(server, -1);
+                    handled = true;
+                    break;
+                }
+                if (sym == XKB_KEY_Down) {
+                    focus_launcher_offset(server, 1);
+                    handled = true;
+                    break;
+                }
+            }
+        }
+    }
+
     if (!handled) {
         wlr_seat_set_keyboard(seat, wlr_keyboard);
         wlr_seat_keyboard_notify_key(seat, event->time_msec, event->keycode, event->state);
     }
 }
+
+void cursor_handle_motion(struct wl_listener *listener, void *data) {
+    ArolloaServer *server = wl_container_of(listener, server, cursor_motion);
+    auto *event = static_cast<struct wlr_pointer_motion_event *>(data);
+    wlr_cursor_move(server->cursor, event->device, event->delta_x, event->delta_y);
+    server->cursor_x = server->cursor->x;
+    server->cursor_y = server->cursor->y;
+    mark_last_interaction(server);
+    wlr_seat_pointer_notify_motion(server->seat, event->time_msec, server->cursor_x, server->cursor_y);
+}
+
+void cursor_handle_motion_absolute(struct wl_listener *listener, void *data) {
+    ArolloaServer *server = wl_container_of(listener, server, cursor_motion_absolute);
+    auto *event = static_cast<struct wlr_pointer_motion_absolute_event *>(data);
+    wlr_cursor_warp_absolute(server->cursor, event->device, event->x, event->y);
+    server->cursor_x = server->cursor->x;
+    server->cursor_y = server->cursor->y;
+    mark_last_interaction(server);
+    wlr_seat_pointer_notify_motion(server->seat, event->time_msec, server->cursor_x, server->cursor_y);
+}
+
+void cursor_handle_button(struct wl_listener *listener, void *data) {
+    ArolloaServer *server = wl_container_of(listener, server, cursor_button);
+    auto *event = static_cast<struct wlr_pointer_button_event *>(data);
+
+    bool handled = handle_panel_click(server, event);
+    handled = handle_launcher_click(server, event) || handled;
+
+    if (!handled) {
+        wlr_seat_pointer_notify_button(server->seat, event->time_msec, event->button, event->state);
+    }
+    mark_last_interaction(server);
+}
+
+void cursor_handle_axis(struct wl_listener *listener, void *data) {
+    ArolloaServer *server = wl_container_of(listener, server, cursor_axis);
+    auto *event = static_cast<struct wlr_pointer_axis_event *>(data);
+    wlr_seat_pointer_notify_axis(server->seat, event->time_msec, event->orientation, event->delta,
+                                 event->delta_discrete, event->source);
+    mark_last_interaction(server);
+}
+
+void cursor_handle_frame(struct wl_listener *listener, void *data) {
+    (void)data;
+    ArolloaServer *server = wl_container_of(listener, server, cursor_frame);
+    wlr_seat_pointer_notify_frame(server->seat);
+}
+
+void seat_handle_request_cursor(struct wl_listener *listener, void *data) {
+    ArolloaServer *server = wl_container_of(listener, server, request_cursor);
+    auto *event = static_cast<struct wlr_seat_pointer_request_set_cursor_event *>(data);
+
+    if (event->seat_client == server->seat->pointer_state.focused_client) {
+        wlr_cursor_set_surface(server->cursor, event->surface, event->hotspot_x, event->hotspot_y);
+    }
+}
+
+void seat_handle_set_selection(struct wl_listener *listener, void *data) {
+    ArolloaServer *server = wl_container_of(listener, server, request_set_selection);
+    auto *event = static_cast<struct wlr_seat_request_set_selection_event *>(data);
+    wlr_seat_set_selection(server->seat, event->source, event->serial);
+}
+
 } // namespace
+
+void ensure_default_cursor(ArolloaServer *server) {
+    if (!server || !server->cursor) {
+        return;
+    }
+
+    if (server->cursor_mgr) {
+        if (wlr_xcursor_manager_set_cursor_image(server->cursor_mgr, "left_ptr", server->cursor)) {
+            return;
+        }
+    }
+
+    if (server->fallback_cursor_pixels.empty()) {
+        server->fallback_cursor_size = 32;
+        server->fallback_cursor_stride = server->fallback_cursor_size * 4;
+        server->fallback_cursor_pixels = build_forest_cursor(server->fallback_cursor_size);
+    }
+
+    if (!server->fallback_cursor_pixels.empty()) {
+        wlr_cursor_set_image(
+            server->cursor,
+            reinterpret_cast<const uint8_t *>(server->fallback_cursor_pixels.data()),
+            static_cast<int32_t>(server->fallback_cursor_stride),
+            server->fallback_cursor_size,
+            server->fallback_cursor_size,
+            1,
+            1);
+    }
+}
+
+void toggle_launcher(ArolloaServer *server) {
+    if (!server) {
+        return;
+    }
+
+    if (server->ui_state.launcher_entries.empty()) {
+        server->ui_state.launcher_visible = false;
+        return;
+    }
+
+    server->ui_state.launcher_visible = !server->ui_state.launcher_visible;
+    if (server->ui_state.highlighted_index >= server->ui_state.launcher_entries.size()) {
+        server->ui_state.highlighted_index = 0;
+    }
+    mark_last_interaction(server);
+}
+
+void focus_launcher_offset(ArolloaServer *server, int offset) {
+    if (!server || server->ui_state.launcher_entries.empty()) {
+        return;
+    }
+
+    const int count = static_cast<int>(server->ui_state.launcher_entries.size());
+    int index = static_cast<int>(server->ui_state.highlighted_index);
+    index = (index + offset) % count;
+    if (index < 0) {
+        index += count;
+    }
+    server->ui_state.highlighted_index = static_cast<std::size_t>(index);
+    mark_last_interaction(server);
+}
+
+bool activate_launcher_selection(ArolloaServer *server) {
+    if (!server || server->ui_state.launcher_entries.empty()) {
+        return false;
+    }
+
+    const auto &entry = server->ui_state.launcher_entries[server->ui_state.highlighted_index];
+    spawn_command_async(entry.command);
+    server->ui_state.launcher_visible = false;
+    mark_last_interaction(server);
+    return true;
+}
+
+void setup_pointer_interactions(ArolloaServer *server) {
+    if (!server || !server->cursor) {
+        return;
+    }
+
+    server->cursor_motion.notify = cursor_handle_motion;
+    wl_signal_add(&server->cursor->events.motion, &server->cursor_motion);
+
+    server->cursor_motion_absolute.notify = cursor_handle_motion_absolute;
+    wl_signal_add(&server->cursor->events.motion_absolute, &server->cursor_motion_absolute);
+
+    server->cursor_button.notify = cursor_handle_button;
+    wl_signal_add(&server->cursor->events.button, &server->cursor_button);
+
+    server->cursor_axis.notify = cursor_handle_axis;
+    wl_signal_add(&server->cursor->events.axis, &server->cursor_axis);
+
+    server->cursor_frame.notify = cursor_handle_frame;
+    wl_signal_add(&server->cursor->events.frame, &server->cursor_frame);
+
+    server->request_cursor.notify = seat_handle_request_cursor;
+    wl_signal_add(&server->seat->events.request_set_cursor, &server->request_cursor);
+
+    server->request_set_selection.notify = seat_handle_set_selection;
+    wl_signal_add(&server->seat->events.request_set_selection, &server->request_set_selection);
+}
+
+void teardown_pointer_interactions(ArolloaServer *server) {
+    if (!server) {
+        return;
+    }
+
+    remove_listener_safe(&server->cursor_motion);
+    remove_listener_safe(&server->cursor_motion_absolute);
+    remove_listener_safe(&server->cursor_button);
+    remove_listener_safe(&server->cursor_axis);
+    remove_listener_safe(&server->cursor_frame);
+    remove_listener_safe(&server->request_cursor);
+    remove_listener_safe(&server->request_set_selection);
+}
 
 void server_new_input(struct wl_listener *listener, void *data) {
     ArolloaServer *server = wl_container_of(listener, server, new_input);
@@ -49,7 +434,7 @@ void server_new_input(struct wl_listener *listener, void *data) {
 
     switch (device->type) {
         case WLR_INPUT_DEVICE_KEYBOARD: {
-            ArolloaKeyboard *keyboard = static_cast<ArolloaKeyboard *>(calloc(1, sizeof(ArolloaKeyboard)));
+            auto *keyboard = static_cast<ArolloaKeyboard *>(calloc(1, sizeof(ArolloaKeyboard)));
             if (!keyboard) {
                 return;
             }
@@ -83,13 +468,22 @@ void server_new_input(struct wl_listener *listener, void *data) {
             wlr_seat_set_keyboard(server->seat, wlr_keyboard);
             break;
         }
-        case WLR_INPUT_DEVICE_POINTER:
+        case WLR_INPUT_DEVICE_POINTER: {
+            if (server->cursor) {
+                wlr_cursor_attach_input_device(server->cursor, device);
+            }
+            server->pointer_connected = true;
+            ensure_default_cursor(server);
             break;
+        }
         default:
             break;
     }
 
-    uint32_t caps = WL_SEAT_CAPABILITY_POINTER;
+    uint32_t caps = 0;
+    if (server->pointer_connected) {
+        caps |= WL_SEAT_CAPABILITY_POINTER;
+    }
     if (!wl_list_empty(&server->keyboards)) {
         caps |= WL_SEAT_CAPABILITY_KEYBOARD;
     }

--- a/src/core/compositor_output.cpp
+++ b/src/core/compositor_output.cpp
@@ -1,40 +1,249 @@
 #include "../../include/arolloa.h"
 
 #include <algorithm>
+#include <cmath>
 #include <cstdlib>
 #include <ctime>
+#include <sstream>
 
 #include <wlr/render/pass.h>
+#include <drm_fourcc.h>
 
 namespace {
 float linear_interpolate(float from, float to, float t) {
     return from + (to - from) * t;
 }
 
+constexpr double kPi = 3.14159265358979323846;
+constexpr double kHalfPi = kPi / 2.0;
+
 struct timespec get_monotonic_time() {
     struct timespec ts = {};
     clock_gettime(CLOCK_MONOTONIC, &ts);
     return ts;
 }
+
+SwissDesign::Color lerp_color(const SwissDesign::Color &a, const SwissDesign::Color &b, float t) {
+    return SwissDesign::Color(
+        linear_interpolate(a.r, b.r, t),
+        linear_interpolate(a.g, b.g, t),
+        linear_interpolate(a.b, b.b, t),
+        linear_interpolate(a.a, b.a, t));
+}
+
+void set_source_color(cairo_t *cairo, const SwissDesign::Color &color, float opacity) {
+    cairo_set_source_rgba(cairo, color.r, color.g, color.b, color.a * opacity);
+}
+
+int count_mapped_views(const ArolloaServer *server) {
+    int count = 0;
+    ArolloaView *view = nullptr;
+    wl_list_for_each(view, &server->views, link) {
+        if (view->mapped) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+std::string format_debug_info(const ArolloaServer *server) {
+    std::ostringstream ss;
+    ss << (server->nested_backend_active ? "Nested" : "Direct");
+    ss << " | Views " << count_mapped_views(server);
+    ss << " | Cursor " << static_cast<int>(server->cursor_x) << "," << static_cast<int>(server->cursor_y);
+    ss << " | Animations " << (server->animations.empty() ? "idle" : std::to_string(server->animations.size()));
+    return ss.str();
+}
+
+void apply_font(PangoLayout *layout, const std::string &font, int size_pt) {
+    PangoFontDescription *desc = pango_font_description_from_string((font + " " + std::to_string(size_pt)).c_str());
+    pango_layout_set_font_description(layout, desc);
+    pango_font_description_free(desc);
+}
+
+void draw_text(cairo_t *cr, PangoLayout *layout, const std::string &text, double x, double y,
+               const SwissDesign::Color &color, float opacity, PangoAlignment alignment = PANGO_ALIGN_LEFT) {
+    if (!layout) {
+        return;
+    }
+    cairo_save(cr);
+    cairo_move_to(cr, x, y);
+    pango_layout_set_alignment(layout, alignment);
+    pango_layout_set_width(layout, -1);
+    pango_layout_set_text(layout, text.c_str(), -1);
+    set_source_color(cr, color, opacity);
+    pango_cairo_show_layout(cr, layout);
+    cairo_restore(cr);
+}
+
+void draw_panel_apps(cairo_t *cr, const ArolloaServer *server, float opacity) {
+    const double icon_size = 28.0;
+    const double spacing = 12.0;
+    double x = FOREST_PANEL_MENU_WIDTH + spacing;
+    const double y = (SwissDesign::PANEL_HEIGHT - icon_size) / 2.0;
+
+    for (const auto &app : server->ui_state.panel_apps) {
+        cairo_save(cr);
+        cairo_rectangle(cr, x, y, icon_size, icon_size);
+        set_source_color(cr, SwissDesign::Forest::MOSS_ACCENT, opacity * 0.85f);
+        cairo_fill(cr);
+        cairo_restore(cr);
+
+        if (server->pango_layout) {
+            apply_font(server->pango_layout, SwissDesign::SECONDARY_FONT, 9);
+            draw_text(cr, server->pango_layout, app.icon_label, x + 6.0, y + 6.0,
+                      SwissDesign::Forest::BARK, opacity);
+        }
+
+        x += icon_size + spacing;
+    }
+}
+
+void draw_tray_icons(cairo_t *cr, const ArolloaServer *server, int width, float opacity) {
+    double x = static_cast<double>(width) - 16.0;
+    const double icon_size = 22.0;
+
+    for (auto it = server->ui_state.tray_icons.rbegin(); it != server->ui_state.tray_icons.rend(); ++it) {
+        x -= icon_size;
+        cairo_save(cr);
+        cairo_arc(cr, x + icon_size / 2.0, SwissDesign::PANEL_HEIGHT / 2.0, icon_size / 2.5, 0, 2 * kPi);
+        set_source_color(cr, it->color, opacity * 0.9f);
+        cairo_fill(cr);
+        cairo_restore(cr);
+
+        if (server->pango_layout) {
+            apply_font(server->pango_layout, SwissDesign::SECONDARY_FONT, 8);
+            draw_text(cr, server->pango_layout, it->label, x - 2.0, SwissDesign::PANEL_HEIGHT / 2.0 - 6.0,
+                      SwissDesign::WHITE, opacity, PANGO_ALIGN_LEFT);
+        }
+
+        x -= 18.0;
+    }
+}
+
+void draw_panel_branding(cairo_t *cr, const ArolloaServer *server, float opacity) {
+    if (!server->pango_layout) {
+        return;
+    }
+    apply_font(server->pango_layout, SwissDesign::PRIMARY_FONT, 14);
+    draw_text(cr, server->pango_layout, "Arolloa", 18.0, SwissDesign::PANEL_HEIGHT / 2.0 - 8.0,
+              SwissDesign::Forest::SUNLIGHT, opacity);
+    apply_font(server->pango_layout, SwissDesign::SECONDARY_FONT, 9);
+    draw_text(cr, server->pango_layout, "Launcher", FOREST_PANEL_MENU_WIDTH - 58.0, SwissDesign::PANEL_HEIGHT / 2.0 + 2.0,
+              SwissDesign::Forest::CANOPY_LIGHT, opacity, PANGO_ALIGN_RIGHT);
+}
+
+void draw_panel_debug(cairo_t *cr, const ArolloaServer *server, int width, float opacity) {
+    if (!server->pango_layout) {
+        return;
+    }
+    apply_font(server->pango_layout, SwissDesign::MONO_FONT, 9);
+    draw_text(cr, server->pango_layout, format_debug_info(server), width * 0.35,
+              SwissDesign::PANEL_HEIGHT / 2.0 - 6.0, SwissDesign::Forest::SUNLIGHT, opacity);
+}
+
+void draw_rounded_rect(cairo_t *cr, double x, double y, double width, double height, double radius) {
+    cairo_new_path(cr);
+    cairo_arc(cr, x + width - radius, y + radius, radius, -kHalfPi, 0);
+    cairo_arc(cr, x + width - radius, y + height - radius, radius, 0, kHalfPi);
+    cairo_arc(cr, x + radius, y + height - radius, radius, kHalfPi, kPi);
+    cairo_arc(cr, x + radius, y + radius, radius, kPi, 3 * kHalfPi);
+    cairo_close_path(cr);
+}
+
+void render_launcher_overlay(cairo_t *cr, ArolloaServer *server, int width, int height, float opacity) {
+    if (!server->ui_state.launcher_visible || !server->pango_layout) {
+        return;
+    }
+
+    cairo_save(cr);
+    set_source_color(cr, SwissDesign::Forest::CANOPY_DARK, 0.55f * opacity);
+    cairo_rectangle(cr, 0, 0, width, height);
+    cairo_fill(cr);
+
+    const double panel_width = FOREST_LAUNCHER_WIDTH;
+    const double panel_height = std::min<double>(height * 0.6,
+        std::max<double>(SwissDesign::PANEL_HEIGHT * 4.0,
+            server->ui_state.launcher_entries.size() * FOREST_LAUNCHER_ENTRY_HEIGHT + 120.0));
+    const double start_x = (width - panel_width) / 2.0;
+    const double start_y = (height - panel_height) / 2.0;
+
+    draw_rounded_rect(cr, start_x, start_y, panel_width, panel_height, 18.0);
+    set_source_color(cr, SwissDesign::Forest::CANOPY_LIGHT, 0.95f * opacity);
+    cairo_fill(cr);
+
+    apply_font(server->pango_layout, SwissDesign::PRIMARY_FONT, 16);
+    draw_text(cr, server->pango_layout, "Forest Launcher", start_x + 32.0, start_y + 26.0,
+              SwissDesign::Forest::BARK, opacity);
+
+    apply_font(server->pango_layout, SwissDesign::SECONDARY_FONT, 10);
+    draw_text(cr, server->pango_layout, "Launch curated system tools and applications",
+              start_x + 32.0, start_y + 54.0, SwissDesign::Forest::BARK, opacity * 0.9f);
+
+    double entry_y = start_y + 88.0;
+    std::size_t index = 0;
+    for (const auto &entry : server->ui_state.launcher_entries) {
+        const bool highlighted = index == server->ui_state.highlighted_index;
+        cairo_save(cr);
+        draw_rounded_rect(cr, start_x + 24.0, entry_y, panel_width - 48.0, FOREST_LAUNCHER_ENTRY_HEIGHT - 8.0, 12.0);
+        if (highlighted) {
+            set_source_color(cr, SwissDesign::Forest::MOSS_ACCENT, 0.65f * opacity);
+        } else {
+            set_source_color(cr, SwissDesign::Forest::CANOPY_MID, 0.35f * opacity);
+        }
+        cairo_fill(cr);
+        cairo_restore(cr);
+
+        apply_font(server->pango_layout, SwissDesign::PRIMARY_FONT, 13);
+        draw_text(cr, server->pango_layout, entry.name, start_x + 48.0, entry_y + 12.0,
+                  SwissDesign::WHITE, opacity);
+
+        apply_font(server->pango_layout, SwissDesign::SECONDARY_FONT, 9);
+        draw_text(cr, server->pango_layout, entry.description, start_x + 48.0, entry_y + 32.0,
+                  SwissDesign::Forest::SUNLIGHT, opacity * 0.9f);
+
+        apply_font(server->pango_layout, SwissDesign::MONO_FONT, 8);
+        draw_text(cr, server->pango_layout, entry.category, start_x + panel_width - 120.0,
+                  entry_y + 14.0, SwissDesign::Forest::BARK, opacity, PANGO_ALIGN_RIGHT);
+
+        entry_y += FOREST_LAUNCHER_ENTRY_HEIGHT;
+        ++index;
+    }
+
+    apply_font(server->pango_layout, SwissDesign::SECONDARY_FONT, 9);
+    draw_text(cr, server->pango_layout, "Hint: Super + Space toggles the launcher",
+              start_x + 32.0, start_y + panel_height - 42.0, SwissDesign::Forest::SUNLIGHT, opacity * 0.8f);
+
+    cairo_restore(cr);
+}
+
 } // namespace
 
-void render_swiss_panel(cairo_t *cairo, int width, int height, float opacity) {
+void render_swiss_panel(cairo_t *cairo, int width, int height, float opacity, const ArolloaServer *server) {
     (void)height;
-    cairo_set_source_rgba(cairo, SwissDesign::WHITE.r, SwissDesign::WHITE.g, SwissDesign::WHITE.b, opacity);
+    cairo_pattern_t *pattern = cairo_pattern_create_linear(0, 0, 0, SwissDesign::PANEL_HEIGHT);
+    auto top_color = SwissDesign::Forest::CANOPY_DARK;
+    auto bottom_color = SwissDesign::Forest::CANOPY_LIGHT;
+    cairo_pattern_add_color_stop_rgba(pattern, 0.0, top_color.r, top_color.g, top_color.b, opacity);
+    cairo_pattern_add_color_stop_rgba(pattern, 1.0, bottom_color.r, bottom_color.g, bottom_color.b, opacity);
+
+    cairo_save(cairo);
     cairo_rectangle(cairo, 0, 0, width, SwissDesign::PANEL_HEIGHT);
+    cairo_set_source(cairo, pattern);
     cairo_fill(cairo);
+    cairo_restore(cairo);
+    cairo_pattern_destroy(pattern);
 
-    cairo_set_source_rgba(cairo, SwissDesign::LIGHT_GREY.r, SwissDesign::LIGHT_GREY.g, SwissDesign::LIGHT_GREY.b, opacity);
-    cairo_set_line_width(cairo, SwissDesign::BORDER_WIDTH);
-    cairo_move_to(cairo, 0, SwissDesign::PANEL_HEIGHT - 1);
-    cairo_line_to(cairo, width, SwissDesign::PANEL_HEIGHT - 1);
-    cairo_stroke(cairo);
+    cairo_save(cairo);
+    cairo_rectangle(cairo, 0, SwissDesign::PANEL_HEIGHT - SwissDesign::BORDER_WIDTH, width, SwissDesign::BORDER_WIDTH);
+    set_source_color(cairo, SwissDesign::Forest::MOSS_ACCENT, opacity);
+    cairo_fill(cairo);
+    cairo_restore(cairo);
 
-    cairo_set_source_rgba(cairo, SwissDesign::SWISS_RED.r, SwissDesign::SWISS_RED.g, SwissDesign::SWISS_RED.b, opacity);
-    cairo_select_font_face(cairo, SwissDesign::PRIMARY_FONT, CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_BOLD);
-    cairo_set_font_size(cairo, 14);
-    cairo_move_to(cairo, 16, 20);
-    cairo_show_text(cairo, "Arolloa");
+    draw_panel_branding(cairo, server, opacity);
+    draw_panel_apps(cairo, server, opacity);
+    draw_tray_icons(cairo, server, width, opacity);
+    draw_panel_debug(cairo, server, width, opacity);
 }
 
 void render_swiss_window(cairo_t *cairo, ArolloaView *view, float global_opacity) {
@@ -43,12 +252,12 @@ void render_swiss_window(cairo_t *cairo, ArolloaView *view, float global_opacity
     }
 
     const float opacity = view->opacity * global_opacity;
-    cairo_set_source_rgba(cairo, SwissDesign::WHITE.r, SwissDesign::WHITE.g, SwissDesign::WHITE.b, opacity * 0.9f);
+    set_source_color(cairo, SwissDesign::Forest::CANOPY_LIGHT, opacity * 0.85f);
     cairo_rectangle(cairo, view->x, view->y, 400, 300);
     cairo_fill(cairo);
 
-    cairo_set_source_rgba(cairo, SwissDesign::GREY.r, SwissDesign::GREY.g, SwissDesign::GREY.b, opacity);
     cairo_set_line_width(cairo, SwissDesign::BORDER_WIDTH);
+    set_source_color(cairo, SwissDesign::Forest::BARK, opacity);
     cairo_rectangle(cairo, view->x, view->y, 400, 300);
     cairo_stroke(cairo);
 }
@@ -68,16 +277,48 @@ void render_swiss_ui(ArolloaServer *server, ArolloaOutput *output) {
         server->cairo_ctx = cairo_create(server->ui_surface);
     }
 
-    cairo_set_source_rgba(server->cairo_ctx, SwissDesign::WHITE.r, SwissDesign::WHITE.g, SwissDesign::WHITE.b, 1.0f);
+    cairo_save(server->cairo_ctx);
+    cairo_set_operator(server->cairo_ctx, CAIRO_OPERATOR_SOURCE);
+    cairo_set_source_rgba(server->cairo_ctx, 0, 0, 0, 0);
     cairo_paint(server->cairo_ctx);
+    cairo_restore(server->cairo_ctx);
 
     const float opacity = std::clamp(server->startup_opacity, 0.0f, 1.0f);
-    render_swiss_panel(server->cairo_ctx, width, height, opacity);
+    render_swiss_panel(server->cairo_ctx, width, height, opacity, server);
+    render_launcher_overlay(server->cairo_ctx, server, width, height, opacity);
 
-    ArolloaView *view = nullptr;
-    wl_list_for_each(view, &server->views, link) {
-        render_swiss_window(server->cairo_ctx, view, opacity);
+    cairo_surface_flush(server->ui_surface);
+}
+
+void initialize_forest_ui(ArolloaServer *server) {
+    if (!server) {
+        return;
     }
+
+    server->ui_state.panel_apps = {
+        {"Files", "thunar", "Fs"},
+        {"Terminal", "foot", "Tm"},
+        {"Browser", "firefox", "Web"}
+    };
+
+    server->ui_state.tray_icons = {
+        {"NET", "Network status", SwissDesign::Forest::SUNLIGHT},
+        {"VOL", "Audio level", SwissDesign::Forest::MOSS_ACCENT},
+        {"PWR", "Power status", SwissDesign::Forest::BARK}
+    };
+
+    server->ui_state.launcher_entries = {
+        {"Forest Terminal", "foot", "A minimalist Wayland terminal optimized for clarity.", "System"},
+        {"Web Browser", "firefox", "Launch a modern browser with privacy enhancements.", "Internet"},
+        {"File Manager", "thunar", "Browse the Swiss filesystem with precision.", "Productivity"},
+        {"Settings", "./build/arolloa-settings", "Configure the compositor without GTK dependencies.", "Control"},
+        {"Flatpak Manager", "flatpak run com.valvesoftware.Steam", "Access packaged applications and games.", "Apps"},
+        {"System Monitor", "gnome-system-monitor", "Inspect processes and resource utilization.", "Diagnostics"}
+    };
+
+    server->ui_state.launcher_visible = false;
+    server->ui_state.highlighted_index = 0;
+    server->ui_state.last_interaction = std::chrono::steady_clock::now();
 }
 
 void output_frame(struct wl_listener *listener, void *data) {
@@ -92,12 +333,6 @@ void output_frame(struct wl_listener *listener, void *data) {
     wlr_output_effective_resolution(output->wlr_output, &width, &height);
 
     const float fade = std::clamp(server->startup_opacity, 0.0f, 1.0f);
-    const float background[4] = {
-        linear_interpolate(SwissDesign::LIGHT_GREY.r, SwissDesign::WHITE.r, fade),
-        linear_interpolate(SwissDesign::LIGHT_GREY.g, SwissDesign::WHITE.g, fade),
-        linear_interpolate(SwissDesign::LIGHT_GREY.b, SwissDesign::WHITE.b, fade),
-        1.0f
-    };
 
     struct wlr_output_state state;
     wlr_output_state_init(&state);
@@ -108,22 +343,29 @@ void output_frame(struct wl_listener *listener, void *data) {
         return;
     }
 
-    const struct wlr_box background_box = {
+    const struct wlr_box top_box = {
         .x = 0,
         .y = 0,
         .width = width,
-        .height = height,
+        .height = height / 2,
     };
+    struct wlr_render_rect_options top_rect = {};
+    top_rect.box = top_box;
+    auto top_color = lerp_color(SwissDesign::Forest::CANOPY_DARK, SwissDesign::Forest::CANOPY_MID, fade);
+    top_rect.color = {.r = top_color.r * fade, .g = top_color.g * fade, .b = top_color.b * fade, .a = fade};
+    wlr_render_pass_add_rect(render_pass, &top_rect);
 
-    struct wlr_render_rect_options background_rect = {};
-    background_rect.box = background_box;
-    background_rect.color = {
-        .r = background[0] * background[3],
-        .g = background[1] * background[3],
-        .b = background[2] * background[3],
-        .a = background[3],
+    const struct wlr_box bottom_box = {
+        .x = 0,
+        .y = height / 2,
+        .width = width,
+        .height = height - height / 2,
     };
-    wlr_render_pass_add_rect(render_pass, &background_rect);
+    struct wlr_render_rect_options bottom_rect = {};
+    bottom_rect.box = bottom_box;
+    auto bottom_color = lerp_color(SwissDesign::Forest::CANOPY_MID, SwissDesign::Forest::CANOPY_LIGHT, fade);
+    bottom_rect.color = {.r = bottom_color.r * fade, .g = bottom_color.g * fade, .b = bottom_color.b * fade, .a = fade};
+    wlr_render_pass_add_rect(render_pass, &bottom_rect);
 
     const struct wlr_box panel_box = {
         .x = 0,
@@ -134,29 +376,9 @@ void output_frame(struct wl_listener *listener, void *data) {
 
     struct wlr_render_rect_options panel_rect = {};
     panel_rect.box = panel_box;
-    panel_rect.color = {
-        .r = SwissDesign::WHITE.r * fade,
-        .g = SwissDesign::WHITE.g * fade,
-        .b = SwissDesign::WHITE.b * fade,
-        .a = fade,
-    };
+    auto panel_color = lerp_color(SwissDesign::Forest::CANOPY_DARK, SwissDesign::Forest::CANOPY_LIGHT, 0.35f);
+    panel_rect.color = {.r = panel_color.r * fade, .g = panel_color.g * fade, .b = panel_color.b * fade, .a = fade};
     wlr_render_pass_add_rect(render_pass, &panel_rect);
-
-    const struct wlr_box accent_box = {
-        .x = 0,
-        .y = SwissDesign::PANEL_HEIGHT - SwissDesign::BORDER_WIDTH,
-        .width = width,
-        .height = SwissDesign::BORDER_WIDTH
-    };
-    struct wlr_render_rect_options accent_rect = {};
-    accent_rect.box = accent_box;
-    accent_rect.color = {
-        .r = SwissDesign::SWISS_RED.r * fade,
-        .g = SwissDesign::SWISS_RED.g * fade,
-        .b = SwissDesign::SWISS_RED.b * fade,
-        .a = fade,
-    };
-    wlr_render_pass_add_rect(render_pass, &accent_rect);
 
     animation_tick(server);
 
@@ -183,7 +405,6 @@ void output_frame(struct wl_listener *listener, void *data) {
             .height = surface->current.height
         };
 
-
         struct wlr_render_texture_options texture_options = {};
         texture_options.texture = texture;
         texture_options.dst_box = box;
@@ -195,81 +416,27 @@ void output_frame(struct wl_listener *listener, void *data) {
         wlr_surface_send_frame_done(surface, &now);
     }
 
+    render_swiss_ui(server, output);
+    struct wlr_texture *ui_texture = wlr_texture_from_pixels(server->renderer, DRM_FORMAT_ARGB8888,
+        cairo_image_surface_get_stride(server->ui_surface), width, height,
+        cairo_image_surface_get_data(server->ui_surface));
+    if (ui_texture) {
+        struct wlr_render_texture_options ui_options = {};
+        ui_options.texture = ui_texture;
+        ui_options.dst_box = {
+            .x = 0,
+            .y = 0,
+            .width = width,
+            .height = height,
+        };
+        wlr_render_pass_add_texture(render_pass, &ui_options);
+        wlr_texture_destroy(ui_texture);
+    }
+
     if (!wlr_render_pass_submit(render_pass)) {
         wlr_output_state_finish(&state);
         return;
     }
 
-    if (!wlr_output_commit_state(output->wlr_output, &state)) {
-        wlr_output_state_finish(&state);
-        return;
-    }
-
     wlr_output_state_finish(&state);
-}
-
-static void output_request_state(struct wl_listener *listener, void *data) {
-    ArolloaOutput *output = wl_container_of(listener, output, request_state);
-    const auto *event = static_cast<const struct wlr_output_event_request_state *>(data);
-    wlr_output_commit_state(output->wlr_output, event->state);
-}
-
-void server_new_output(struct wl_listener *listener, void *data) {
-    ArolloaServer *server = wl_container_of(listener, server, new_output);
-    auto *wlr_output = static_cast<struct wlr_output *>(data);
-
-    if (!wlr_output_init_render(wlr_output, server->allocator, server->renderer)) {
-        wlr_log(WLR_ERROR, "Failed to initialize output render resources");
-        return;
-    }
-
-    struct wlr_output_state state;
-    wlr_output_state_init(&state);
-    wlr_output_state_set_enabled(&state, true);
-
-    if (!wl_list_empty(&wlr_output->modes)) {
-        struct wlr_output_mode *mode = wlr_output_preferred_mode(wlr_output);
-        if (mode) {
-            wlr_output_state_set_mode(&state, mode);
-        }
-    }
-
-    if (!wlr_output_commit_state(wlr_output, &state)) {
-        wlr_log(WLR_ERROR, "Failed to commit initial output state");
-        wlr_output_state_finish(&state);
-        return;
-    }
-    wlr_output_state_finish(&state);
-
-    ArolloaOutput *output = static_cast<ArolloaOutput *>(calloc(1, sizeof(ArolloaOutput)));
-    if (!output) {
-        return;
-    }
-
-    output->wlr_output = wlr_output;
-    output->server = server;
-    output->last_frame = get_monotonic_time();
-
-    output->frame.notify = output_frame;
-    wl_signal_add(&wlr_output->events.frame, &output->frame);
-
-
-    output->request_state.notify = output_request_state;
-
-    wl_signal_add(&wlr_output->events.request_state, &output->request_state);
-
-    output->destroy.notify = [](struct wl_listener *listener, void *data) {
-        (void)data;
-        ArolloaOutput *output = wl_container_of(listener, output, destroy);
-        wl_list_remove(&output->frame.link);
-        wl_list_remove(&output->request_state.link);
-        wl_list_remove(&output->link);
-        free(output);
-    };
-    wl_signal_add(&wlr_output->events.destroy, &output->destroy);
-
-    wl_list_insert(&server->outputs, &output->link);
-    wlr_output_layout_add_auto(server->output_layout, wlr_output);
-
-    wlr_log(WLR_INFO, "Registered output '%s'", wlr_output->name);
 }

--- a/src/core/compositor_server_runtime.cpp
+++ b/src/core/compositor_server_runtime.cpp
@@ -79,9 +79,16 @@ void server_destroy(ArolloaServer *server) {
         return;
     }
 
+    teardown_pointer_interactions(server);
+
     if (server->cursor_mgr) {
         wlr_xcursor_manager_destroy(server->cursor_mgr);
         server->cursor_mgr = nullptr;
+    }
+
+    if (server->cursor) {
+        wlr_cursor_destroy(server->cursor);
+        server->cursor = nullptr;
     }
 
     if (server->seat) {
@@ -148,6 +155,10 @@ void server_destroy(ArolloaServer *server) {
 
     destroy_display(server);
 
+    server->fallback_cursor_pixels.clear();
+    server->ui_state.panel_apps.clear();
+    server->ui_state.tray_icons.clear();
+    server->ui_state.launcher_entries.clear();
     server->animations.clear();
     server->initialized = false;
 }

--- a/src/settings/settings_simple.cpp
+++ b/src/settings/settings_simple.cpp
@@ -1,31 +1,229 @@
-#include <iostream>
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
 #include <fstream>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <sstream>
 #include <string>
+#include <vector>
+
+namespace {
+const char *kConfigRelativePath = "/.config/arolloa/config";
+
+std::string config_path() {
+    const char *home = getenv("HOME");
+    if (!home) {
+        home = "/tmp";
+    }
+    return std::string(home) + kConfigRelativePath;
+}
+
+void ensure_config_directory() {
+    const char *home = getenv("HOME");
+    if (!home) {
+        return;
+    }
+    std::string command = std::string("mkdir -p ") + home + "/.config/arolloa";
+    std::system(command.c_str());
+}
+
+std::map<std::string, std::string> load_config() {
+    std::map<std::string, std::string> config;
+    std::ifstream file(config_path());
+    if (!file.good()) {
+        config["layout.mode"] = "grid";
+        config["animation.enabled"] = "true";
+        config["colors.accent"] = "#3a5f2f";
+        config["panel.tray"] = "net,vol,pwr";
+        return config;
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+        auto pos = line.find('=');
+        if (pos == std::string::npos) {
+            continue;
+        }
+        config[line.substr(0, pos)] = line.substr(pos + 1);
+    }
+    return config;
+}
+
+void save_config(const std::map<std::string, std::string> &config) {
+    ensure_config_directory();
+    std::ofstream file(config_path());
+    for (const auto &entry : config) {
+        file << entry.first << "=" << entry.second << '\n';
+    }
+    file.close();
+}
+
+void clear_screen() {
+    std::cout << "\033[2J\033[H";
+}
+
+void show_header() {
+    std::cout << "╔══════════════════════════════════════════════╗\n";
+    std::cout << "║   Arolloa Forest Settings (Console Edition)   ║\n";
+    std::cout << "╠══════════════════════════════════════════════╣\n";
+    std::cout << "║ Configure your compositor without GTK or GUI ║\n";
+    std::cout << "╚══════════════════════════════════════════════╝\n\n";
+}
+
+void show_status(const std::map<std::string, std::string> &config) {
+    std::cout << "Current profile:\n";
+    std::cout << "  • Window layout : " << config.at("layout.mode") << '\n';
+    std::cout << "  • Animations    : " << (config.at("animation.enabled") == "true" ? "enabled" : "disabled") << '\n';
+    std::cout << "  • Accent color  : " << config.at("colors.accent") << '\n';
+    auto it = config.find("panel.tray");
+    if (it != config.end()) {
+        std::cout << "  • Tray icons    : " << it->second << '\n';
+    }
+    std::cout << '\n';
+}
+
+void pause_for_enter() {
+    std::cout << "Press Enter to return to the menu...";
+    std::cout.flush();
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+}
+
+std::string prompt_line(const std::string &prompt, const std::string &fallback = "") {
+    std::cout << prompt;
+    std::string input;
+    std::getline(std::cin, input);
+    if (input.empty()) {
+        return fallback;
+    }
+    return input;
+}
+
+void configure_layout(std::map<std::string, std::string> &config) {
+    clear_screen();
+    show_header();
+    std::cout << "Choose window layout:\n";
+    std::vector<std::pair<std::string, std::string>> layouts = {
+        {"grid", "Balanced grid for tiled workspaces"},
+        {"asym", "Asymmetrical layout for creative flows"},
+        {"floating", "Floating windows for freestyle arrangement"}
+    };
+
+    for (std::size_t i = 0; i < layouts.size(); ++i) {
+        std::cout << "  [" << (i + 1) << "] " << layouts[i].first << " — " << layouts[i].second << '\n';
+    }
+    std::cout << '\n';
+
+    std::string choice = prompt_line("Enter number (current: " + config["layout.mode"] + "): ");
+    if (choice.empty()) {
+        return;
+    }
+
+    std::size_t index = 0;
+    try {
+        index = std::stoul(choice);
+    } catch (...) {
+        std::cout << "Invalid selection." << std::endl;
+        pause_for_enter();
+        return;
+    }
+
+    if (index == 0 || index > layouts.size()) {
+        std::cout << "Invalid selection." << std::endl;
+        pause_for_enter();
+        return;
+    }
+    config["layout.mode"] = layouts[index - 1].first;
+}
+
+void toggle_animation(std::map<std::string, std::string> &config) {
+    bool enabled = config["animation.enabled"] == "true";
+    enabled = !enabled;
+    config["animation.enabled"] = enabled ? "true" : "false";
+    std::cout << "Animations are now " << (enabled ? "enabled" : "disabled") << ".\n";
+}
+
+bool is_hex_color(const std::string &value) {
+    if (value.size() != 7 || value[0] != '#') {
+        return false;
+    }
+    return std::all_of(value.begin() + 1, value.end(), [](unsigned char c) {
+        return std::isxdigit(c);
+    });
+}
+
+void configure_accent(std::map<std::string, std::string> &config) {
+    std::string input = prompt_line("Enter a hex accent color (e.g. #3a5f2f): ", config["colors.accent"]);
+    if (!is_hex_color(input)) {
+        std::cout << "Invalid color format. Keeping " << config["colors.accent"] << "\n";
+        return;
+    }
+    config["colors.accent"] = input;
+}
+
+void configure_tray(std::map<std::string, std::string> &config) {
+    std::cout << "Define tray indicators (comma separated tags, e.g. net,vol,pwr):\n";
+    std::string input = prompt_line("Tray icons [" + config["panel.tray"] + "]: ", config["panel.tray"]);
+    if (!input.empty()) {
+        config["panel.tray"] = input;
+    }
+}
+
+void reset_defaults(std::map<std::string, std::string> &config) {
+    config["layout.mode"] = "grid";
+    config["animation.enabled"] = "true";
+    config["colors.accent"] = "#3a5f2f";
+    config["panel.tray"] = "net,vol,pwr";
+    std::cout << "Defaults restored." << std::endl;
+}
+
+} // namespace
 
 int main() {
-    std::cout << "Arolloa Settings (Minimal)" << std::endl;
-    std::cout << "=========================" << std::endl;
-    std::cout << "This is a minimal settings interface." << std::endl;
-    std::cout << "GUI version requires GTK3 development libraries." << std::endl;
-    std::cout << "To install: sudo apt install libgtk-3-dev" << std::endl;
+    auto config = load_config();
 
-    // Create basic config if it doesn't exist
-    const char* home = getenv("HOME");
-    if (home) {
-        std::string config_dir = std::string(home) + "/.config/arolloa";
-        system(("mkdir -p " + config_dir).c_str());
+    while (true) {
+        clear_screen();
+        show_header();
+        show_status(config);
+        std::cout << "Forest options:\n";
+        std::cout << "  [1] Window layout\n";
+        std::cout << "  [2] Toggle animations\n";
+        std::cout << "  [3] Accent color\n";
+        std::cout << "  [4] Tray icons\n";
+        std::cout << "  [5] Restore defaults\n";
+        std::cout << "  [0] Save and exit\n\n";
+        std::cout << "Select an option: ";
 
-        std::string config_file = config_dir + "/config";
-        std::ifstream test(config_file);
-        if (!test.good()) {
-            std::ofstream config(config_file);
-            config << "layout.mode=grid" << std::endl;
-            config << "animation.enabled=true" << std::endl;
-            config << "colors.accent=#cc0000" << std::endl;
-            config.close();
-            std::cout << "Created basic configuration at " << config_file << std::endl;
+        std::string choice;
+        std::getline(std::cin, choice);
+        if (choice == "0" || choice == "q" || choice == "Q") {
+            break;
+        }
+
+        if (choice == "1") {
+            configure_layout(config);
+        } else if (choice == "2") {
+            toggle_animation(config);
+            pause_for_enter();
+        } else if (choice == "3") {
+            configure_accent(config);
+            pause_for_enter();
+        } else if (choice == "4") {
+            configure_tray(config);
+            pause_for_enter();
+        } else if (choice == "5") {
+            reset_defaults(config);
+            pause_for_enter();
+        } else {
+            std::cout << "Unknown choice." << std::endl;
+            pause_for_enter();
         }
     }
 
+    save_config(config);
+    std::cout << "Configuration saved to " << config_path() << "\n";
+    std::cout << "Launch the compositor to see your forest changes." << std::endl;
     return 0;
 }


### PR DESCRIPTION
## Summary
- add cursor and pointer infrastructure with fallback forest cursor art and launcher controls
- render a forest-inspired panel, tray, and launcher overlay with debug information and application metadata
- replace the minimal GTK note with an interactive console settings tool that manages compositor preferences

## Testing
- ./build.sh *(fails: missing wayland-scanner in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f3f5f1188326ae9bd321eb1fbffa